### PR TITLE
Fix code scanning alert no. 2: Incorrect conversion between integer types

### DIFF
--- a/pkg/gateway/pkg.go
+++ b/pkg/gateway/pkg.go
@@ -207,15 +207,27 @@ func RunAsDaemon(mainOptions config.Options) error {
 		if err != nil {
 			return fmt.Errorf("failed to lookup user %s: %w", mainOptions.User, err)
 		}
-		uid, _ := strconv.Atoi(u.Uid)
-		gid, _ := strconv.Atoi(u.Gid)
+		uid64, err := strconv.ParseUint(u.Uid, 10, 32)
+		if err != nil {
+			return fmt.Errorf("failed to parse uid %s: %w", u.Uid, err)
+		}
+		uid := uint32(uid64)
+		gid64, err := strconv.ParseUint(u.Gid, 10, 32)
+		if err != nil {
+			return fmt.Errorf("failed to parse gid %s: %w", u.Gid, err)
+		}
+		gid := uint32(gid64)
 
 		if mainOptions.Group != "" {
 			g, err := user.LookupGroup(mainOptions.Group)
 			if err != nil {
 				return fmt.Errorf("failed to lookup group %s: %w", mainOptions.Group, err)
 			}
-			gid, _ = strconv.Atoi(g.Gid)
+			gid64, err = strconv.ParseUint(g.Gid, 10, 32)
+			if err != nil {
+				return fmt.Errorf("failed to parse gid %s: %w", g.Gid, err)
+			}
+			gid = uint32(gid64)
 		}
 
 		setUserAndGroup(cmd, uint32(uid), uint32(gid))


### PR DESCRIPTION
Fixes [https://github.com/nite-coder/bifrost/security/code-scanning/2](https://github.com/nite-coder/bifrost/security/code-scanning/2)

To fix the problem, we need to ensure that the integer values parsed from strings are within the bounds of `uint32` before performing the conversion. This can be achieved by using `strconv.ParseUint` with a specified bit size of 32, which directly returns a `uint64` type. We can then safely cast this to `uint32` after ensuring it is within the valid range.

- Replace `strconv.Atoi` with `strconv.ParseUint` specifying a bit size of 32.
- Check the bounds of the parsed value to ensure it fits within `uint32`.
- Update the relevant lines in the `RunAsDaemon` function.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
