### PR TITLE
Fix code scanning alert no. 3: Incorrect conversion between integer types

### DIFF
--- a/pkg/zero/zero.go
+++ b/pkg/zero/zero.go
@@ -257,7 +257,7 @@ func (z *ZeroDownTime) Shutdown(ctx context.Context) error {
 		return err
 	}
 
-	pid, err := strconv.ParseInt(string(b), 10, 64)
+	pid, err := strconv.ParseInt(string(b), 10, 32)
 	if err != nil {
 		slog.Error("pid is invalid", "error", err)
 		return err


### PR DESCRIPTION
Fixes [https://github.com/nite-coder/bifrost/security/code-scanning/3](https://github.com/nite-coder/bifrost/security/code-scanning/3)

To fix the problem, we need to ensure that the `pid` value is within the range of a 32-bit integer before converting it. We can achieve this by checking if the parsed `pid` is within the bounds of a 32-bit integer. If it is not, we should handle the error appropriately.

- Use `strconv.ParseInt` with a bit size of 32 to directly parse the value as a 32-bit integer.
- Alternatively, if we need to keep the 64-bit parsing, add a check to ensure the value is within the 32-bit range before converting it.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
