### PR TITLE
Fix code scanning alert no. 4: Size computation for allocation may overflow

### DIFF
--- a/pkg/proxy/grpc/proxy.go
+++ b/pkg/proxy/grpc/proxy.go
@@ -339,6 +339,11 @@ func (p *GRPCProxy) handleGRPCError(ctx context.Context, c *app.RequestContext, 
 func makeGRPCErrorFrame(st *status.Status) []byte {
 	statusProto := st.Proto()
 	serialized, _ := proto.Marshal(statusProto)
+	if len(serialized) > (1<<31 - 6) { // Check for potential overflow
+		// Handle the error appropriately, e.g., log and return an empty frame
+		log.Error("Serialized data too large to create gRPC error frame")
+		return []byte{}
+	}
 	frame := make([]byte, len(serialized)+5)
 	frame[0] = 0 // 0: no compression
 	binary.BigEndian.PutUint32(frame[1:5], uint32(len(serialized)))


### PR DESCRIPTION
Fixes [https://github.com/nite-coder/bifrost/security/code-scanning/4](https://github.com/nite-coder/bifrost/security/code-scanning/4)

To fix the problem, we need to ensure that the length of the serialized data does not cause an overflow when calculating the size for the buffer allocation. We can do this by checking the length of the serialized data before performing the addition and allocation. If the length is too large, we should handle the error appropriately.

1. Add a check to ensure that `len(serialized)` is within a safe range before performing the addition.
2. If the length is too large, return an error or handle it in a way that prevents the overflow.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
