### PR TITLE
Fix code scanning alert no. 6: Size computation for allocation may overflow

### DIFF
--- a/pkg/proxy/grpc/proxy.go
+++ b/pkg/proxy/grpc/proxy.go
@@ -350,7 +350,7 @@ func makeGRPCErrorFrame(st *status.Status) []byte {
 	serialized, _ := proto.Marshal(statusProto)
 
 	val := len(serialized)
-	if val > math.MaxUint32-6 || val < 0 {
+	if val < 0 || uint64(val) > math.MaxUint32-5 {
 		// Check for potential overflow
 		// Handle the error appropriately, e.g., log and return an empty frame
 		return []byte{}


### PR DESCRIPTION
Fixes [https://github.com/nite-coder/bifrost/security/code-scanning/6](https://github.com/nite-coder/bifrost/security/code-scanning/6)

To fix the problem, we need to ensure that the size computation for the allocation does not overflow. This can be achieved by:
1. Adding a more comprehensive check to ensure `val` is within a safe range before performing the allocation.
2. Using a wider type (such as `uint64`) for the size computation to handle larger values safely.

We will modify the code to:
1. Check if `val` is within the range of `0` to `math.MaxUint32-5` before proceeding with the allocation.
2. Return an empty frame if the check fails, ensuring the program does not attempt an unsafe allocation.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
