### PR TITLE
fix: `$http.start` and `$http.finish` need to be unix micro time when…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@
 
 - When the service encounters a `no free connections available to host` error, return HTTP status code `500` instead of `502`
 - During the upgrade process, existing connections will be gracefully closed.
+- `$http.start` and `$http.finish` need to be unix micro time when working with `ResponseTransformer` middleware
 
 ### **Refactor**
 

--- a/pkg/tracer/accesslog/tracer.go
+++ b/pkg/tracer/accesslog/tracer.go
@@ -112,14 +112,6 @@ func (t *Tracer) buildReplacer(c *app.RequestContext) []string {
 			}
 
 			replacements = append(replacements, variable.HTTPResponseStatusCode, status)
-		case variable.HTTPStart:
-			httpStart := variable.GetTime(variable.HTTPStart, c)
-			val, _ := cast.ToString(httpStart.UnixMicro())
-			replacements = append(replacements, variable.HTTPStart, val)
-		case variable.HTTPFinish:
-			httpFinish := variable.GetTime(variable.HTTPFinish, c)
-			val, _ := cast.ToString(httpFinish.UnixMicro())
-			replacements = append(replacements, variable.HTTPFinish, val)
 		default:
 			val := variable.GetString(key, c)
 			replacements = append(replacements, key, val)

--- a/pkg/variable/pkg.go
+++ b/pkg/variable/pkg.go
@@ -101,8 +101,20 @@ func GetString(key string, c *app.RequestContext) string {
 	if !found {
 		return ""
 	}
-	result, _ := cast.ToString(val)
-	return result
+
+	switch key {
+	case HTTPStart:
+		httpStart := GetTime(HTTPStart, c)
+		val, _ := cast.ToString(httpStart.UnixMicro())
+		return val
+	case HTTPFinish:
+		httpFinish := GetTime(HTTPFinish, c)
+		val, _ := cast.ToString(httpFinish.UnixMicro())
+		return val
+	default:
+		result, _ := cast.ToString(val)
+		return result
+	}
 }
 
 func GetInt64(key string, c *app.RequestContext) int64 {


### PR DESCRIPTION
… working with `ResponseTransformer` middleware