### PR TITLE
refactor: keep original `host` header value when forwading a request …

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@
 - improve `variable.HTTPRequestMethod` performance ([#41](https://github.com/nite-coder/bifrost/pull/41))
 - struct alignment for better performance and lower memory usage ([#42](https://github.com/nite-coder/bifrost/pull/42))
 - improve client cancel request when context is Canceled ([#45](https://github.com/nite-coder/bifrost/pull/45))
+- keep original `host` header value when forwading a request to upstream ([#47](https://github.com/nite-coder/bifrost/pull/47))
 
 ### **Test**
 

--- a/pkg/proxy/http/proxy.go
+++ b/pkg/proxy/http/proxy.go
@@ -150,10 +150,16 @@ func New(opts Options, client *client.Client) (proxy.Proxy, error) {
 				req.SetIsTLS(true)
 			default:
 			}
+
+			host := req.Header.Get("host")
+			req.SetRequestURI(cast.B2S(JoinURLPath(req, opts.Target)))
+
 			if opts.HeaderHost != "" {
 				req.Header.Set("Host", opts.HeaderHost)
+			} else {
+				req.Header.Set("Host", host)
 			}
-			req.SetRequestURI(cast.B2S(JoinURLPath(req, opts.Target)))
+
 		},
 		client: client,
 	}

--- a/pkg/proxy/http/proxy_test.go
+++ b/pkg/proxy/http/proxy_test.go
@@ -61,7 +61,7 @@ func TestReverseProxy(t *testing.T) {
 			t.Errorf("handler got Proxy-Connection header value %q", c)
 		}
 
-		if c := ctx.Request.Header.Get("Host"); c != "127.0.0.1" {
+		if c := ctx.Request.Header.Get("Host"); c != "abc.com" {
 			t.Errorf("handler got Host header value %q", c)
 		}
 
@@ -86,7 +86,6 @@ func TestReverseProxy(t *testing.T) {
 		Target:           "http://127.0.0.1:9990/proxy",
 		Protocol:         config.ProtocolHTTP,
 		Weight:           1,
-		HeaderHost:       "127.0.0.1",
 		IsTracingEnabled: true,
 	}
 
@@ -115,8 +114,9 @@ func TestReverseProxy(t *testing.T) {
 	req.Header.Set("Proxy-Connection", "should be deleted")
 	req.Header.Set("Upgrade", "foo")
 	req.SetConnectionClose()
-	req.SetHost("some-name")
 	req.SetRequestURI("http://localhost:9990/backend")
+	req.Header.Set("Host", "abc.com")
+
 	_ = cli.Do(context.Background(), req, res)
 	if err != nil {
 		t.Fatalf("Get: %v", err)


### PR DESCRIPTION
…to upstream